### PR TITLE
Fix Next.js build by removing remote font dependency and aligning Prisma setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+apps/*/node_modules
+packages/*/node_modules
+.next
+apps/*/.next
+packages/*/.next
+.turbo
+.env
+.env.local
+.env.*.local
+.prisma
+.DS_Store
+

--- a/apps/merchant-app/app/api/user/route.ts
+++ b/apps/merchant-app/app/api/user/route.ts
@@ -1,16 +1,24 @@
-import { NextResponse } from "next/server"
-import { PrismaClient } from "@repo/db/client";
-
-const client = new PrismaClient();
+import { NextResponse } from "next/server";
 
 export const GET = async () => {
-    await client.user.create({
-        data: {
-            email: "asd",
-            name: "adsads"
-        }
-    })
+  if (!process.env.DATABASE_URL) {
     return NextResponse.json({
-        message: "hi there"
-    })
-}
+      message: "hi there",
+    });
+  }
+
+  const { default: db } = await import("@repo/db/client");
+  await db.user.create({
+    data: {
+      email: "asd",
+      name: "adsads",
+      number: "0000000000",
+      password: "placeholder",
+    },
+  });
+
+  return NextResponse.json({
+    message: "hi there",
+  });
+};
+

--- a/apps/merchant-app/app/globals.css
+++ b/apps/merchant-app/app/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}

--- a/apps/merchant-app/app/layout.tsx
+++ b/apps/merchant-app/app/layout.tsx
@@ -1,9 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { Providers } from "../provider";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Create Turborepo",
@@ -17,9 +14,9 @@ export default function RootLayout({
 }): JSX.Element {
   return (
     <html lang="en">
-      <Providers>
-        <body className={inter.className}>{children}</body>
-      </Providers>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/merchant-app/app/page.tsx
+++ b/apps/merchant-app/app/page.tsx
@@ -2,9 +2,7 @@
 
 import { useBalance } from "@repo/store/balance";
 
-export default function() {
+export default function Page(): JSX.Element {
   const balance = useBalance();
-  return <div>
-    hi there {balance}
-  </div>
+  return <div>hi there {balance}</div>;
 }

--- a/apps/merchant-app/next.config.js
+++ b/apps/merchant-app/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  transpilePackages: ["@repo/ui"],
+  transpilePackages: ["@repo/ui", "@repo/store"],
 };

--- a/apps/user-app/app/globals.css
+++ b/apps/user-app/app/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}

--- a/apps/user-app/app/layout.tsx
+++ b/apps/user-app/app/layout.tsx
@@ -1,9 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { Providers } from "../provider";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Create Turborepo",
@@ -17,9 +14,9 @@ export default function RootLayout({
 }): JSX.Element {
   return (
     <html lang="en">
-      <Providers>
-        <body className={inter.className}>{children}</body>
-      </Providers>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/user-app/next.config.js
+++ b/apps/user-app/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  transpilePackages: ["@repo/ui"],
+  transpilePackages: ["@repo/ui", "@repo/store"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,10 +1161,11 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.11.0.tgz",
-      "integrity": "sha512-SWshvS5FDXvgJKM/a0y9nDC1rqd7KG0Q6ZVzd+U7ZXK5soe73DJxJJgbNBt2GNXOa+ysWB4suTpdK5zfFPhwiw==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.13"
       },
@@ -1178,48 +1179,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.11.0.tgz",
-      "integrity": "sha512-N6yYr3AbQqaiUg+OgjkdPp3KPW1vMTAgtKX6+BiB/qB2i1TjLYCrweKcUjzOoRM5BriA4idrkTej9A9QqTfl3A==",
-      "devOptional": true
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.11.0.tgz",
-      "integrity": "sha512-gbrpQoBTYWXDRqD+iTYMirDlF9MMlQdxskQXbhARhG6A/uFQjB7DZMYocMQLoiZXO/IskfDOZpPoZE8TBQKtEw==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.11.0",
-        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
-        "@prisma/fetch-engine": "5.11.0",
-        "@prisma/get-platform": "5.11.0"
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
-      "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
-      "devOptional": true
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.11.0.tgz",
-      "integrity": "sha512-994viazmHTJ1ymzvWugXod7dZ42T2ROeFuH6zHPcUfp/69+6cl5r9u3NFb6bW8lLdNjwLYEVPeu3hWzxpZeC0w==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.11.0",
-        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
-        "@prisma/get-platform": "5.11.0"
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.11.0.tgz",
-      "integrity": "sha512-rxtHpMLxNTHxqWuGOLzR2QOyQi79rK1u1XYAVLZxDGTLz/A+uoDnjz9veBFlicrpWjwuieM4N6jcnjj/DDoidw==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.11.0"
+        "@prisma/debug": "5.22.0"
       }
     },
     "node_modules/@repo/db": {
@@ -7671,19 +7677,23 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prisma": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.11.0.tgz",
-      "integrity": "sha512-KCLiug2cs0Je7kGkQBN9jDWoZ90ogE/kvZTUTgz2h94FEo8pczCkPH7fPNXkD1sGU7Yh65risGGD1HQ5DF3r3g==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.11.0"
+        "@prisma/engines": "5.22.0"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
         "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/prop-types": {
@@ -9803,10 +9813,10 @@
       "name": "@repo/db",
       "version": "0.0.0",
       "dependencies": {
-        "@prisma/client": "^5.11.0"
+        "@prisma/client": "5.22.0"
       },
       "devDependencies": {
-        "prisma": "5.11.0"
+        "prisma": "5.22.0"
       }
     },
     "packages/eslint-config": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,12 +2,13 @@
     "name": "@repo/db",
     "version": "0.0.0",
     "dependencies": {
-        "@prisma/client": "^5.11.0"
+        "@prisma/client": "5.22.0"
     },
     "devDependencies": {
-        "prisma": "5.11.0"
+        "prisma": "5.22.0"
     },
     "exports": {
         "./client": "./index.ts"
     }
 }
+

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -6,6 +6,10 @@
     "recoil": "^0.7.7"
   },
   "exports": {
-    "./balance": "./src/hooks/useBalance"
+    "./balance": {
+      "types": "./src/hooks/useBalance.ts",
+      "default": "./src/hooks/useBalance.ts"
+    }
   }
 }
+

--- a/packages/store/src/atoms/balance.ts
+++ b/packages/store/src/atoms/balance.ts
@@ -1,7 +1,6 @@
-
 import { atom } from "recoil";
 
 export const balanceAtom = atom<number>({
-    key: "balance",
-    default: 0,
-})
+  key: "balance",
+  default: 0,
+});

--- a/packages/store/src/hooks/useBalance.ts
+++ b/packages/store/src/hooks/useBalance.ts
@@ -1,7 +1,7 @@
-import { useRecoilValue } from "recoil"
-import { balanceAtom } from "../atoms/balance"
+import { useRecoilValue } from "recoil";
+import { balanceAtom } from "../atoms/balance";
 
-export const useBalance = () => {
-    const value = useRecoilValue(balanceAtom);
-    return value;
-}
+export const useBalance = (): number => {
+  const value = useRecoilValue(balanceAtom);
+  return value;
+};


### PR DESCRIPTION
## Summary
- remove the Google font dependency from both app layouts and rely on a shared CSS fallback while keeping providers inside the `<body>` element
- update the shared store package exports and Next.js configs so workspace hooks are transpiled and typed cleanly
- bump Prisma packages, gate the sample API route on an available database URL, and add a repository `.gitignore` to keep installs out of version control

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c886b1e01c832fb46733a9bea19963